### PR TITLE
Changing ROF parameters for aligning the CESM workflow

### DIFF
--- a/examples/key_metrics/config.yml
+++ b/examples/key_metrics/config.yml
@@ -154,16 +154,14 @@ compute_notebooks:
           none:
             analysis_name: ""
             grid_name: 'f09_f09_mosart' # ROF grid name
-            rof_start_date: '0091-01-01'
-            rof_end_date: '0101-01-01'
+            climo_nyears: 10
             figureSave: False
       global_discharge_ocean_compare_obs:
         parameter_groups:
           none:
             analysis_name: ""
             grid_name: 'f09_f09_mosart' # ROF grid name
-            rof_start_date: '0091-01-01'
-            rof_end_date: '0101-01-01'
+            climo_nyears: 10
             figureSave: False
 
     ice:

--- a/nblibrary/rof/global_discharge_gauge_compare_obs.ipynb
+++ b/nblibrary/rof/global_discharge_gauge_compare_obs.ipynb
@@ -52,7 +52,9 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
@@ -70,7 +72,6 @@
     "import xarray as xr\n",
     "import cartopy.crs as ccrs\n",
     "import cartopy.feature as cfeature\n",
-    "from dask.distributed import Client, LocalCluster\n",
     "\n",
     "import scripts.colors as colors\n",
     "import scripts.metrics as metric\n",
@@ -110,74 +111,27 @@
    "source": [
     "# Parameter Defaults\n",
     "# parameters are set in CUPiD's config.yml file\n",
+    "# when running interactively, manually set the parameters below\n",
     "\n",
-    "CESM_output_dir = \"\"\n",
-    "case_name = None  # case name\n",
-    "base_case_name = None  # base case name\n",
-    "start_date = \"\"\n",
-    "end_date = \"\"\n",
-    "serial = False  # use dask LocalCluster\n",
+    "# global parameters\n",
+    "CESM_output_dir = \"\"  # e.g., \"/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CESM_output_for_testing\"\n",
+    "case_name = None  # case name: e.g., \"b.e30_beta02.BLT1850.ne30_t232.104\"\n",
+    "base_case_name = None  # base case name: e.g., \"b.e23_alpha17f.BLT1850.ne30_t232.092\"\n",
+    "start_date = \"\"  # simulation starting date: e.g., \"0001-01-01\"\n",
+    "end_date = \"\"  # simulation ending date: \"0100-01-01\"\n",
+    "base_start_date = \"\"  # base simulation starting date: \"0001-01-01\"\n",
+    "base_end_date = \"\"  # base simulation ending date: \"0100-01-01\"\n",
+    "serial = True  # use dask LocalCluster\n",
     "lc_kwargs = {}\n",
     "\n",
+    "# rof parameters\n",
     "analysis_name = \"\"  # Used for Figure png names\n",
-    "if analysis_name:\n",
-    "    analysis_name = case_name\n",
-    "rof_start_date = start_date  # specify if different starting yyyy-mm-dd is desired\n",
-    "rof_end_date = end_date  # specify if different ending yyyy-mm-dd is desired\n",
+    "climo_nyears = 10  # number of years to compute the climatology\n",
     "grid_name = \"f09_f09_mosart\"  # ROF grid name used in case\n",
     "base_grid_name = (\n",
     "    grid_name  # spcify ROF grid name for base_case in config.yml if different than case\n",
     ")\n",
     "figureSave = False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "-------------------------\n",
-    "ROF ancillary data specification "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "setup = load_yaml(\"./setup/setup.yaml\")\n",
-    "\n",
-    "ancillary_dir = setup[\n",
-    "    \"ancillary_dir\"\n",
-    "]  # ancillary directory including ROF domain, river network data etc.\n",
-    "ref_flow_dir = setup[\"ref_flow_dir\"]  # including observed or reference flow data\n",
-    "case_meta = setup[\"case_meta\"]  # Case metadata\n",
-    "reach_gpkg = setup[\"reach_gpkg\"]  # river reach geopackage meta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "case_list = [case for case in [case_name, base_case_name] if case is not None]\n",
-    "grid_list = [grid for grid in [grid_name, base_grid_name] if grid is not None]\n",
-    "time_period = slice(f\"{rof_start_date}\", f\"{rof_end_date}\")  # analysis time period\n",
-    "nyrs = int(rof_end_date[:4]) - int(rof_start_date[:4]) + 1  # number of years\n",
-    "nmons = nyrs * 12  # number of months\n",
-    "year_list = [\n",
-    "    \"{:04d}\".format(yr)\n",
-    "    for yr in np.arange(int(rof_start_date[0:4]), int(rof_end_date[0:4]) + 1)\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "-----\n",
-    "### dasks (optional)"
    ]
   },
   {
@@ -192,12 +146,81 @@
    },
    "outputs": [],
    "source": [
-    "# Spin up cluster (if running in parallel)\n",
-    "client = None\n",
-    "if not serial:\n",
-    "    cluster = LocalCluster(**lc_kwargs)\n",
-    "    client = Client(cluster)\n",
+    "# ROF additional setup\n",
+    "setup = load_yaml(\"./setup/setup.yaml\")\n",
     "\n",
+    "ancillary_dir = setup[\n",
+    "    \"ancillary_dir\"\n",
+    "]  # ancillary directory including ROF domain, river network data etc.\n",
+    "ref_flow_dir = setup[\"ref_flow_dir\"]  # including observed or reference flow data\n",
+    "case_meta = setup[\"case_meta\"]  # Case metadata\n",
+    "reach_gpkg = setup[\"reach_gpkg\"]  # river reach geopackage meta\n",
+    "\n",
+    "if analysis_name:\n",
+    "    analysis_name = case_name\n",
+    "if base_grid_name:\n",
+    "    base_grid_name = grid_name\n",
+    "\n",
+    "case_dic = {\n",
+    "    case_name: {\n",
+    "        \"grid\": grid_name,\n",
+    "        \"sim_period\": slice(f\"{start_date}\", f\"{end_date}\"),\n",
+    "        \"climo_nyrs\": min(climo_nyears, int(end_date[:4]) - int(start_date[:4]) + 1),\n",
+    "    },\n",
+    "    base_case_name: {\n",
+    "        \"grid\": grid_name,\n",
+    "        \"sim_period\": slice(f\"{base_start_date}\", f\"{base_end_date}\"),\n",
+    "        \"climo_nyrs\": min(climo_nyears, int(end_date[:4]) - int(start_date[:4]) + 1),\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dasks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# When running interactively, cupid_run should be set to False\n",
+    "cupid_run = True\n",
+    "\n",
+    "client = None\n",
+    "if cupid_run:\n",
+    "    # Spin up cluster (if running in parallel)\n",
+    "    if not serial:\n",
+    "        from dask.distributed import Client, LocalCluster\n",
+    "\n",
+    "        cluster = LocalCluster(**lc_kwargs)\n",
+    "        client = Client(cluster)\n",
+    "else:\n",
+    "    if not serial:\n",
+    "        from dask.distributed import Client\n",
+    "        from dask_jobqueue import PBSCluster\n",
+    "\n",
+    "        cluster = PBSCluster(\n",
+    "            cores=1,\n",
+    "            processes=1,\n",
+    "            memory=\"50GB\",\n",
+    "            queue=\"casper\",\n",
+    "            walltime=\"01:00:00\",\n",
+    "        )\n",
+    "        cluster.scale(jobs=10)\n",
+    "        client = Client(cluster)\n",
     "client"
    ]
   },
@@ -221,7 +244,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -230,43 +261,58 @@
     "month_data = {}\n",
     "year_data = {}\n",
     "seas_data = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    in_dire = os.path.join(CESM_output_dir, case, \"rof/hist\")\n",
-    "    model = case_meta[grid][\"model\"]\n",
-    "    domain = case_meta[grid][\"domain_nc\"]\n",
-    "    var_list = case_meta[grid][\"vars_read\"]\n",
+    "    model = case_meta[meta[\"grid\"]][\"model\"]\n",
+    "    domain = case_meta[meta[\"grid\"]][\"domain_nc\"]\n",
+    "    var_list = case_meta[meta[\"grid\"]][\"vars_read\"]\n",
     "\n",
     "    def preprocess(ds):\n",
     "        return ds[var_list]\n",
     "\n",
-    "    # monthly\n",
+    "    year_list = [\n",
+    "        \"{:04d}\".format(yr)\n",
+    "        for yr in np.arange(\n",
+    "            int(meta[\"sim_period\"].start[0:4]), int(meta[\"sim_period\"].stop[0:4]) + 1\n",
+    "        )\n",
+    "    ]\n",
+    "\n",
     "    nc_list = []\n",
     "    for nc_path in sorted(glob.glob(f\"{in_dire}/{case}.{model}.h*.????-*.nc\")):\n",
     "        for yr in year_list:\n",
     "            if yr in os.path.basename(nc_path):\n",
     "                nc_list.append(nc_path)\n",
     "\n",
-    "    month_data[case] = (\n",
-    "        xr.open_mfdataset(\n",
-    "            nc_list,\n",
-    "            data_vars=\"minimal\",\n",
-    "            parallel=True,\n",
-    "            preprocess=preprocess,\n",
-    "        )\n",
-    "        .sel(time=time_period)\n",
+    "    # load data\n",
+    "    ds = xr.open_mfdataset(\n",
+    "        nc_list,\n",
+    "        data_vars=\"minimal\",\n",
+    "        parallel=True,\n",
+    "        preprocess=preprocess,\n",
+    "    ).sel(time=meta[\"sim_period\"])\n",
+    "\n",
+    "    # monthly\n",
+    "    month_data[case] = ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None)).load()\n",
+    "    # annual\n",
+    "    year_data[case] = (\n",
+    "        ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None))\n",
+    "        .resample(time=\"YS\")\n",
+    "        .mean(dim=\"time\")\n",
     "        .load()\n",
     "    )\n",
-    "    # annual\n",
-    "    year_data[case] = month_data[case].resample(time=\"YS\").mean(dim=\"time\")\n",
-    "\n",
     "    # seasonal (compute here instead of reading for conisistent analysis period)\n",
-    "    seas_data[case] = month_data[case].groupby(\"time.month\").mean(\"time\")\n",
+    "    seas_data[case] = (\n",
+    "        ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None))\n",
+    "        .groupby(\"time.month\")\n",
+    "        .mean(\"time\")\n",
+    "        .load()\n",
+    "    )\n",
     "    vars_no_time = no_time_variable(month_data[case])\n",
     "    if vars_no_time:\n",
     "        seas_data[case][vars_no_time] = seas_data[case][vars_no_time].isel(\n",
     "            month=0, drop=True\n",
     "        )\n",
-    "    time = month_data[case][\"time\"]\n",
+    "    mon_time = month_data[case].time.values\n",
     "    if domain == \"None\":\n",
     "        reachID[case] = month_data[case][\"reachID\"].values\n",
     "    else:\n",
@@ -286,7 +332,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "df = pd.read_csv(\"./setup/large_river_50.txt\", index_col=\"river_name\")\n",
@@ -307,13 +361,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "gauge_reach_lnk = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    gauge_reach_lnk[case] = pd.read_csv(\n",
-    "        \"%s/D09/D09_925.%s.asc\" % (ref_flow_dir, case_meta[grid][\"network\"])\n",
+    "        \"%s/D09/D09_925.%s.asc\" % (ref_flow_dir, case_meta[meta[\"grid\"]][\"network\"])\n",
     "    )"
    ]
   },
@@ -328,7 +390,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -352,7 +422,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -368,11 +446,11 @@
     "\n",
     "# monthly - if time_period is outside observation period, use the entire obs period\n",
     "obs_available = True\n",
-    "if ds_q[\"time\"].sel(time=time_period).values.size == 0:\n",
+    "if ds_q[\"time\"].sel(time=slice(str(mon_time[0]), str(mon_time[-1]))).values.size == 0:\n",
     "    obs_available = False\n",
     "    ds_q_obs_mon = ds_q[\"FLOW\"]\n",
     "else:\n",
-    "    ds_q_obs_mon = ds_q[\"FLOW\"].sel(time=time_period)\n",
+    "    ds_q_obs_mon = ds_q[\"FLOW\"].sel(time=slice(str(mon_time[0]), str(mon_time[-1])))\n",
     "# compute annual flow from monthly\n",
     "ds_q_obs_yr = ds_q_obs_mon.resample(time=\"YE\").mean(dim=\"time\")\n",
     "# compute annual cycle at monthly scale\n",
@@ -399,14 +477,16 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
     "gauge_plot = {}\n",
     "for gname, site_id in big_river_50.items():\n",
     "    gauge_plot[gname] = {}\n",
-    "    for case in case_list:\n",
+    "    for case in case_dic.keys():\n",
     "        gauge_ix = [\n",
     "            i for i, gid in enumerate(ds_q.id.values) if gid == site_id\n",
     "        ]  # go through obs Dataset and get index matching to river (gauge) name\n",
@@ -446,7 +526,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -459,11 +547,11 @@
     "for ix, river_name in enumerate(big_river_24.keys()):\n",
     "    row = ix // 3\n",
     "    col = ix % 3\n",
-    "    for case, grid in zip(case_list, grid_list):\n",
+    "    for case, meta in case_dic.items():\n",
     "        net_idx = gauge_plot[river_name][case][1]\n",
     "        gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
-    "        q_name = case_meta[grid][\"flow_name\"]\n",
+    "        q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
     "        if len(net_idx) == 1:\n",
     "            year_data[case][q_name][:, net_idx].plot(\n",
@@ -530,7 +618,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -543,12 +639,11 @@
     "for ix, river_name in enumerate(big_river_24.keys()):\n",
     "    row = ix // 3\n",
     "    col = ix % 3\n",
-    "    for case, grid in zip(case_list, grid_list):\n",
-    "\n",
+    "    for case, meta in case_dic.items():\n",
     "        net_idx = gauge_plot[river_name][case][1]\n",
     "        gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
-    "        q_name = case_meta[grid][\"flow_name\"]\n",
+    "        q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
     "        if len(net_idx) == 1:  # means vector\n",
     "            seas_data[case][q_name][:, net_idx].plot(\n",
@@ -602,7 +697,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -619,23 +722,19 @@
     "        col = ix % 3\n",
     "        axes[row, col].yaxis.set_major_formatter(FormatStrFormatter(\"%.0f\"))\n",
     "\n",
-    "        for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
+    "        for jx, (case, meta) in enumerate(case_dic.items()):\n",
     "\n",
     "            net_idx = gauge_plot[river_name][case][1]\n",
     "            gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
-    "            q_name = case_meta[grid][\"flow_name\"]\n",
+    "            q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
     "            if len(net_idx) == 1:  # means vector\n",
-    "                ds_sim = month_data[case][q_name][:, net_idx].sel(time=time_period)\n",
+    "                ds_sim = month_data[case][q_name][:, net_idx]\n",
     "            elif len(net_idx) == 2:  # means 2d grid\n",
-    "                ds_sim = (\n",
-    "                    month_data[case][q_name][:, net_idx[0], net_idx[1]]\n",
-    "                    .sel(time=time_period)\n",
-    "                    .squeeze()\n",
-    "                )\n",
+    "                ds_sim = month_data[case][q_name][:, net_idx[0], net_idx[1]].squeeze()\n",
     "\n",
-    "            ds_obs = ds_q_obs_mon.sel(time=time_period).loc[:, gaug_idx]\n",
+    "            ds_obs = ds_q_obs_mon.sel(time=meta[\"time_period\"]).loc[:, gaug_idx]\n",
     "\n",
     "            axes[row, col].plot(\n",
     "                ds_obs, ds_sim, \"o\", label=case, markersize=4.0, alpha=0.4\n",
@@ -697,7 +796,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -713,21 +820,18 @@
     "        col = ix % 3\n",
     "        axes[row, col].yaxis.set_major_formatter(FormatStrFormatter(\"%.0f\"))\n",
     "\n",
-    "        for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
-    "\n",
+    "        for jx, (case, meta) in enumerate(case_dic.items()):\n",
     "            net_idx = gauge_plot[river_name][case][1]\n",
     "            gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
-    "            q_name = case_meta[grid][\"flow_name\"]\n",
+    "            q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
     "            if len(net_idx) == 1:  # means vector\n",
-    "                ds_sim = year_data[case][q_name][:, net_idx].sel(time=time_period)\n",
+    "                ds_sim = year_data[case][q_name][:, net_idx]\n",
     "            elif len(net_idx) == 2:  # means 2d grid\n",
-    "                ds_sim = year_data[case][q_name][:, net_idx[0], net_idx[1]].sel(\n",
-    "                    time=time_period\n",
-    "                )\n",
+    "                ds_sim = year_data[case][q_name][:, net_idx[0], net_idx[1]]\n",
     "\n",
-    "            ds_obs = ds_q_obs_yr.sel(time=time_period).loc[:, gaug_idx]\n",
+    "            ds_obs = ds_q_obs_yr.sel(time=meta[\"time_period\"]).loc[:, gaug_idx]\n",
     "\n",
     "            axes[row, col].plot(\n",
     "                ds_obs, ds_sim, \"o\", label=case, markersize=4.0, alpha=0.4\n",
@@ -796,7 +900,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -810,12 +922,12 @@
     "    # headers\n",
     "    f.write(\"No,          river_name,\")\n",
     "    f.write(\"{0: >15}_vol,\".format(\"obs\"))\n",
-    "    for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
-    "        f.write(\"{0: >15}_vol,\".format(grid))\n",
+    "    for jx, (case, meta) in enumerate(case_dic.items()):\n",
+    "        f.write(\"{0: >15}_vol,\".format(meta[\"grid\"]))\n",
     "    f.write(\"{0: >15}_area\".format(\"obs\"))\n",
-    "    for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
+    "    for jx, (case, meta) in enumerate(case_dic.items()):\n",
     "        f.write(\",\")\n",
-    "        f.write(\"{0: >15}_area\".format(grid))\n",
+    "        f.write(\"{0: >15}_area\".format(meta[\"grid\"]))\n",
     "    f.write(\"\\n\")\n",
     "\n",
     "    # data for each river\n",
@@ -824,18 +936,16 @@
     "        f.write(\"%02d,\" % (ix + 1))\n",
     "        f.write(\"{0: >20}\".format(river_name))\n",
     "\n",
-    "        for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
+    "        for jx, (case, meta) in enumerate(case_dic.items()):\n",
     "            f.write(\",\")\n",
     "            net_idx = gauge_plot[river_name][case][1]\n",
     "            gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
-    "            q_name = case_meta[grid][\"flow_name\"]\n",
+    "            q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
     "            if len(net_idx) == 1:  # means vector\n",
     "                qsim = (\n",
-    "                    np.nanmean(\n",
-    "                        year_data[case][q_name][:, net_idx].sel(time=time_period).values\n",
-    "                    )\n",
+    "                    np.nanmean(year_data[case][q_name][:, net_idx].values)\n",
     "                    * 60\n",
     "                    * 60\n",
     "                    * 24\n",
@@ -845,9 +955,7 @@
     "            elif len(net_idx) == 2:  # means 2d grid\n",
     "                qsim = (\n",
     "                    np.nanmean(\n",
-    "                        year_data[case][q_name][:, net_idx[0], net_idx[1]]\n",
-    "                        .sel(time=time_period)\n",
-    "                        .values\n",
+    "                        year_data[case][q_name][:, net_idx[0], net_idx[1]].values\n",
     "                    )\n",
     "                    * 60\n",
     "                    * 60\n",
@@ -869,7 +977,7 @@
     "\n",
     "            f.write(\"{:19.1f}\".format(qsim))\n",
     "\n",
-    "        for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
+    "        for jx, (case, _) in enumerate(case_dic.items()):\n",
     "            f.write(\",\")\n",
     "            gaug_idx = gauge_plot[river_name][case][0]\n",
     "\n",
@@ -898,7 +1006,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "if obs_available:\n",
@@ -914,15 +1030,14 @@
     "    regressor = LinearRegression()\n",
     "    bias_text = \"\"\n",
     "\n",
-    "    for jx, (case, grid) in enumerate(zip(case_list, grid_list)):\n",
-    "\n",
+    "    for jx, (case, meta) in enumerate(case_dic.items()):\n",
     "        # compute linear regression\n",
-    "        df_reg = df_yr_vol[[\"obs_vol\", f\"{grid}_vol\"]].dropna()\n",
-    "        regressor.fit(df_reg[[\"obs_vol\"]], df_reg[f\"{grid}_vol\"])\n",
+    "        df_reg = df_yr_vol[[\"obs_vol\", f\"{meta['grid']}_vol\"]].dropna()\n",
+    "        regressor.fit(df_reg[[\"obs_vol\"]], df_reg[f\"{meta['grid']}_vol\"])\n",
     "        y_pred = regressor.predict(df_reg[[\"obs_vol\"]])\n",
     "\n",
     "        # compute bias over 50 sites\n",
-    "        diff = (df_yr_vol[f\"{grid}_vol\"] - df_yr_vol[\"obs_vol\"]).mean(\n",
+    "        diff = (df_yr_vol[f\"{meta['grid']}_vol\"] - df_yr_vol[\"obs_vol\"]).mean(\n",
     "            axis=0, skipna=True\n",
     "        )\n",
     "\n",
@@ -930,13 +1045,13 @@
     "            ax=axes,\n",
     "            kind=\"scatter\",\n",
     "            x=\"obs_vol\",\n",
-    "            y=f\"{grid}_vol\",\n",
+    "            y=f\"{meta['grid']}_vol\",\n",
     "            s=30,\n",
     "            alpha=0.6,\n",
-    "            label=grid,\n",
+    "            label=meta[\"grid\"],\n",
     "        )\n",
     "        # plt.plot(df_reg['obs_vol'], y_pred, color=color)\n",
-    "        bias_text = bias_text + f\"\\n{grid}: {diff:.1f} \"\n",
+    "        bias_text = bias_text + f\"\\n{meta['grid']}: {diff:.1f} \"\n",
     "\n",
     "    plt.text(\n",
     "        0.65, 0.30, \"bias [km3/yr]\", transform=axes.transAxes, verticalalignment=\"top\"\n",
@@ -976,7 +1091,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -995,24 +1118,23 @@
     "    mon_corr = {}\n",
     "    mon_rmse = {}\n",
     "\n",
-    "    for case, grid in zip(case_list, grid_list):\n",
-    "\n",
+    "    for case, meta in case_dic.items():\n",
     "        bias = np.full(len(gauge_shp1[case]), np.nan, dtype=float)\n",
     "        corr = np.full(len(gauge_shp1[case]), np.nan, dtype=float)\n",
     "        rmse = np.full(len(gauge_shp1[case]), np.nan, dtype=float)\n",
     "\n",
+    "        q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
+    "\n",
     "        for ix, row in gauge_shp1[case].iterrows():\n",
     "            q_obs = np.full(\n",
-    "                nmons, np.nan, dtype=float\n",
+    "                meta[\"climo_nyrs\"] * 12, np.nan, dtype=float\n",
     "            )  # dummy q_sim that will be replaced by actual data if exist\n",
     "            q_sim = np.full(\n",
-    "                nmons, np.nan, dtype=float\n",
+    "                meta[\"climo_nyrs\"] * 12, np.nan, dtype=float\n",
     "            )  # dummy q_sim that will be replaced by actual data if exist\n",
     "\n",
     "            route_id = row[\"route_id\"]\n",
     "            gauge_id = row[\"gauge_id\"]\n",
-    "\n",
-    "            q_name = case_meta[grid][\"flow_name\"]\n",
     "\n",
     "            gauge_ix = np.argwhere(ds_q.id.values == gauge_id)\n",
     "            if len(gauge_ix) == 1:\n",
@@ -1042,9 +1164,9 @@
     "        mon_corr[case] = corr\n",
     "        mon_rmse[case] = rmse\n",
     "\n",
-    "        gauge_shp1[case][f\"bias_{grid}\"] = bias\n",
-    "        gauge_shp1[case][f\"corr_{grid}\"] = corr\n",
-    "        gauge_shp1[case][f\"rmse_{grid}\"] = rmse"
+    "        gauge_shp1[case][f\"bias_{meta['grid']}\"] = bias\n",
+    "        gauge_shp1[case][f\"corr_{meta['grid']}\"] = corr\n",
+    "        gauge_shp1[case][f\"rmse_{meta['grid']}\"] = rmse"
    ]
   },
   {
@@ -1057,7 +1179,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -1096,7 +1226,7 @@
     "    }\n",
     "\n",
     "    for error_metric in [\"rmse\", \"bias\", \"corr\"]:\n",
-    "        for case, grid in zip(case_list, grid_list):\n",
+    "        for case, meta in case_dic.items():\n",
     "            fig, ax = plt.subplots(\n",
     "                1, figsize=(7.5, 4.0), subplot_kw={\"projection\": ccrs.PlateCarree()}\n",
     "            )\n",
@@ -1108,7 +1238,7 @@
     "\n",
     "            gauge_shp1[case].plot(\n",
     "                ax=ax,\n",
-    "                column=f\"{error_metric}_{grid}\",\n",
+    "                column=f\"{error_metric}_{meta['grid']}\",\n",
     "                markersize=10,\n",
     "                cmap=meta[error_metric][\"cm\"],\n",
     "                vmin=meta[error_metric][\"vmin\"],\n",
@@ -1142,7 +1272,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "if obs_available:\n",
@@ -1152,13 +1290,13 @@
     "    for error_metric in [\"rmse\", \"bias\", \"corr\"]:\n",
     "        column_stat = []\n",
     "        gauge_shp_all_case = gauge_shp.copy(deep=True)\n",
-    "        for case, grid in zip(case_list, grid_list):\n",
+    "        for case, meta in case_dic.items():\n",
     "            gauge_shp_all_case = gauge_shp_all_case.merge(\n",
-    "                gauge_shp1[case][[\"id\", f\"{error_metric}_{grid}\"]],\n",
+    "                gauge_shp1[case][[\"id\", f\"{error_metric}_{meta['grid']}\"]],\n",
     "                left_on=\"id\",\n",
     "                right_on=\"id\",\n",
     "            )\n",
-    "            column_stat.append(f\"{error_metric}_{grid}\")\n",
+    "            column_stat.append(f\"{error_metric}_{meta['grid']}\")\n",
     "        fig, ax = plt.subplots(1, figsize=(6.5, 4))\n",
     "        gauge_shp_all_case.boxplot(\n",
     "            ax=ax,\n",
@@ -1188,9 +1326,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "if client:\n",
+    "    client.shutdown()"
+   ]
   }
  ],
  "metadata": {

--- a/nblibrary/rof/global_discharge_ocean_compare_obs.ipynb
+++ b/nblibrary/rof/global_discharge_ocean_compare_obs.ipynb
@@ -42,7 +42,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
@@ -55,7 +63,6 @@
     "import geopandas as gpd\n",
     "import xarray as xr\n",
     "import cartopy.feature as cfeature\n",
-    "from dask.distributed import Client, LocalCluster\n",
     "\n",
     "from scripts.utility import load_yaml\n",
     "from scripts.utility import no_time_variable\n",
@@ -81,47 +88,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
     "editable": true,
     "slideshow": {
      "slide_type": ""
     },
     "tags": [
-     "parameters"
+     "parameters",
+     "hide-input"
     ]
    },
    "outputs": [],
    "source": [
     "# Parameter Defaults\n",
     "# parameters are set in CUPiD's config.yml file\n",
+    "# when running interactively, manually set the parameters below\n",
     "\n",
     "CESM_output_dir = \"\"\n",
-    "case_name = None  # case name\n",
-    "base_case_name = None  # base case name\n",
+    "case_name = None  # case name: e.g., \"b.e30_beta02.BLT1850.ne30_t232.104\"\n",
+    "base_case_name = None  # base case name: e.g., \"b.e23_alpha17f.BLT1850.ne30_t232.092\"\n",
     "start_date = \"\"\n",
     "end_date = \"\"\n",
-    "serial = False  # use dask LocalCluster\n",
+    "base_start_date = \"\"  # base simulation starting date: \"0001-01-01\"\n",
+    "base_end_date = \"\"  # base simulation ending date: \"0100-01-01\"\n",
+    "serial = True  # use dask LocalCluster\n",
     "lc_kwargs = {}\n",
     "\n",
     "analysis_name = \"\"  # Used for Figure png names\n",
-    "if analysis_name:\n",
-    "    analysis_name = case_name\n",
-    "rof_start_date = start_date  # specify if different starting yyyy-mm-dd is desired\n",
-    "rof_end_date = end_date  # specify if different ending yyyy-mm-dd is desired\n",
+    "climo_nyears = 10  # number of years to compute the climatology\n",
     "grid_name = \"f09_f09_mosart\"  # ROF grid name used in case\n",
     "base_grid_name = (\n",
     "    grid_name  # spcify ROF grid name for base_case in config.yml if different than case\n",
     ")\n",
     "figureSave = False"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "-------------------------\n",
-    "ROF ancillary data specification "
    ]
   },
   {
@@ -132,10 +132,13 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
+    "# ROF additional setup\n",
     "setup = load_yaml(\"./setup/setup.yaml\")\n",
     "\n",
     "domain_dir = setup[\n",
@@ -146,15 +149,25 @@
     "case_meta = setup[\"case_meta\"]  # RO grid meta\n",
     "catch_gpkg = setup[\"catch_gpkg\"]  # catchment geopackage meta\n",
     "reach_gpkg = setup[\"reach_gpkg\"]  # reach geopackage meta\n",
-    "network_nc = setup[\"river_network\"]  # river network meta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "network_nc = setup[\"river_network\"]  # river network meta\n",
+    "\n",
+    "if not analysis_name:\n",
+    "    analysis_name = case_name\n",
+    "if base_grid_name:\n",
+    "    base_grid_name = grid_name\n",
+    "\n",
+    "case_dic = {\n",
+    "    case_name: {\n",
+    "        \"grid\": grid_name,\n",
+    "        \"sim_period\": slice(f\"{start_date}\", f\"{end_date}\"),\n",
+    "        \"climo_nyrs\": min(climo_nyears, int(end_date[:4]) - int(start_date[:4]) + 1),\n",
+    "    },\n",
+    "    base_case_name: {\n",
+    "        \"grid\": grid_name,\n",
+    "        \"sim_period\": slice(f\"{base_start_date}\", f\"{base_end_date}\"),\n",
+    "        \"climo_nyrs\": min(climo_nyears, int(end_date[:4]) - int(start_date[:4]) + 1),\n",
+    "    },\n",
+    "}\n",
     "oceans_list = [\n",
     "    \"arctic\",\n",
     "    \"atlantic\",\n",
@@ -163,15 +176,6 @@
     "    \"pacific\",\n",
     "    \"south_china\",\n",
     "    \"global\",\n",
-    "]\n",
-    "case_list = [case for case in [case_name, base_case_name] if case is not None]\n",
-    "grid_list = [grid for grid in [grid_name, base_grid_name] if grid is not None]\n",
-    "time_period = slice(f\"{rof_start_date}\", f\"{rof_end_date}\")  # analysis time period\n",
-    "nyrs = int(rof_end_date[:4]) - int(rof_start_date[:4]) + 1  # number of years\n",
-    "nmons = nyrs * 12  # number of months\n",
-    "year_list = [\n",
-    "    \"{:04d}\".format(yr)\n",
-    "    for yr in np.arange(int(rof_start_date[0:4]), int(rof_end_date[0:4]) + 1)\n",
     "]"
    ]
   },
@@ -191,16 +195,37 @@
     "slideshow": {
      "slide_type": ""
     },
-    "tags": []
+    "tags": [
+     "hide-input"
+    ]
    },
    "outputs": [],
    "source": [
-    "# Spin up cluster (if running in parallel)\n",
-    "client = None\n",
-    "if not serial:\n",
-    "    cluster = LocalCluster(**lc_kwargs)\n",
-    "    client = Client(cluster)\n",
+    "# When running interactively, cupid_run should be set to False\n",
+    "cupid_run = True\n",
     "\n",
+    "client = None\n",
+    "if cupid_run:\n",
+    "    # Spin up cluster (if running in parallel)\n",
+    "    if not serial:\n",
+    "        from dask.distributed import Client, LocalCluster\n",
+    "\n",
+    "        cluster = LocalCluster(**lc_kwargs)\n",
+    "        client = Client(cluster)\n",
+    "else:\n",
+    "    if not serial:\n",
+    "        from dask.distributed import Client\n",
+    "        from dask_jobqueue import PBSCluster\n",
+    "\n",
+    "        cluster = PBSCluster(\n",
+    "            cores=1,\n",
+    "            processes=1,\n",
+    "            memory=\"50GB\",\n",
+    "            queue=\"casper\",\n",
+    "            walltime=\"01:00:00\",\n",
+    "        )\n",
+    "        cluster.scale(jobs=10)\n",
+    "        client = Client(cluster)\n",
     "client"
    ]
   },
@@ -224,7 +249,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -233,42 +266,58 @@
     "month_data = {}\n",
     "year_data = {}\n",
     "seas_data = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    in_dire = os.path.join(CESM_output_dir, case, \"rof/hist\")\n",
-    "    model = case_meta[grid][\"model\"]\n",
-    "    domain = case_meta[grid][\"domain_nc\"]\n",
-    "    var_list = case_meta[grid][\"vars_read\"]\n",
+    "    model = case_meta[meta[\"grid\"]][\"model\"]\n",
+    "    domain = case_meta[meta[\"grid\"]][\"domain_nc\"]\n",
+    "    var_list = case_meta[meta[\"grid\"]][\"vars_read\"]\n",
     "\n",
     "    def preprocess(ds):\n",
     "        return ds[var_list]\n",
     "\n",
-    "    # monthly\n",
+    "    year_list = [\n",
+    "        \"{:04d}\".format(yr)\n",
+    "        for yr in np.arange(\n",
+    "            int(meta[\"sim_period\"].start[0:4]), int(meta[\"sim_period\"].stop[0:4]) + 1\n",
+    "        )\n",
+    "    ]\n",
+    "\n",
     "    nc_list = []\n",
     "    for nc_path in sorted(glob.glob(f\"{in_dire}/{case}.{model}.h*.????-*.nc\")):\n",
     "        for yr in year_list:\n",
     "            if yr in os.path.basename(nc_path):\n",
     "                nc_list.append(nc_path)\n",
-    "    month_data[case] = (\n",
-    "        xr.open_mfdataset(\n",
-    "            nc_list,\n",
-    "            data_vars=\"minimal\",\n",
-    "            parallel=True,\n",
-    "            preprocess=preprocess,\n",
-    "        )\n",
-    "        .sel(time=time_period)\n",
+    "\n",
+    "    # load data\n",
+    "    ds = xr.open_mfdataset(\n",
+    "        nc_list,\n",
+    "        data_vars=\"minimal\",\n",
+    "        parallel=True,\n",
+    "        preprocess=preprocess,\n",
+    "    ).sel(time=meta[\"sim_period\"])\n",
+    "\n",
+    "    # monthly\n",
+    "    month_data[case] = ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None))\n",
+    "    # annual\n",
+    "    year_data[case] = (\n",
+    "        ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None))\n",
+    "        .resample(time=\"YS\")\n",
+    "        .mean(dim=\"time\")\n",
     "        .load()\n",
     "    )\n",
-    "    # annual\n",
-    "    year_data[case] = month_data[case].resample(time=\"YS\").mean(dim=\"time\")\n",
-    "\n",
     "    # seasonal (compute here instead of reading for conisistent analysis period)\n",
-    "    seas_data[case] = month_data[case].groupby(\"time.month\").mean(\"time\")\n",
+    "    seas_data[case] = (\n",
+    "        ds.isel(time=slice(-meta[\"climo_nyrs\"] * 12, None))\n",
+    "        .groupby(\"time.month\")\n",
+    "        .mean(\"time\")\n",
+    "        .load()\n",
+    "    )\n",
     "    vars_no_time = no_time_variable(month_data[case])\n",
     "    if vars_no_time:\n",
     "        seas_data[case][vars_no_time] = seas_data[case][vars_no_time].isel(\n",
     "            month=0, drop=True\n",
     "        )\n",
-    "    time = month_data[case][\"time\"]\n",
+    "    mon_time = month_data[case].time.values\n",
     "    if domain == \"None\":\n",
     "        reachID[case] = month_data[case][\"reachID\"].values\n",
     "    else:\n",
@@ -277,7 +326,7 @@
     "            .stack(seg=(\"lat\", \"lon\"))\n",
     "            .values\n",
     "        )\n",
-    "    print(case)"
+    "    print(f\"Finished loading {case}\")"
    ]
   },
   {
@@ -293,7 +342,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -309,11 +366,11 @@
     "\n",
     "# monthly- if time_period is outside observation period, use the entire obs period\n",
     "obs_available = True\n",
-    "if ds_q[\"time\"].sel(time=time_period).values.size == 0:\n",
+    "if ds_q[\"time\"].sel(time=slice(str(mon_time[0]), str(mon_time[-1]))).values.size == 0:\n",
     "    obs_available = False\n",
     "    ds_q_obs_mon = ds_q[\"FLOW\"]\n",
     "else:\n",
-    "    ds_q_obs_mon = ds_q[\"FLOW\"].sel(time=time_period)\n",
+    "    ds_q_obs_mon = ds_q[\"FLOW\"].sel(time=slice(str(mon_time[0]), str(mon_time[-1])))\n",
     "# compute annual flow from monthly\n",
     "ds_q_obs_yr = ds_q_obs_mon.resample(time=\"YE\").mean(dim=\"time\")\n",
     "# compute annual cycle at monthly scale\n",
@@ -322,19 +379,32 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "## 3. Reading river, catchment, gauge infomation  <a id='read_ancillary'></a>\n",
     "\n",
-    "- catchment polygon (geopackage)\n",
+    "- gauge-catchment (or grid box) link (csv)\n",
     "- gauge point (geopackage)\n",
-    "- gauge-catchment link (csv)\n",
+    "- ocean polygon (geopackage)\n",
+    "- catchment polygon (geopackage)\n",
     "- outlet reach information (netCDF)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### 3.1. reach-D19 gauge link csv\n",
     "- gauge_reach_lnk (dataframe)"
@@ -343,28 +413,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "gauge_reach_lnk = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    gauge_reach_lnk[case] = pd.read_csv(\n",
-    "        \"%s/D09/D09_925.%s.asc\" % (ref_flow_dir, case_meta[grid][\"network\"])\n",
+    "        \"%s/D09/D09_925.%s.asc\" % (ref_flow_dir, case_meta[meta[\"grid\"]][\"network\"])\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
-    "### 3.2 D19 flow site shapefile\n",
+    "### 3.2 D19 flow site geopackage\n",
     "- gauge_shp (dataframe)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -376,9 +468,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.3 Ocean polygon geopackage\n",
+    "- ocean_shp (dataframe)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
@@ -388,27 +502,39 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### 3.3 Read river network information\n",
-    "- riv_ocean (dataframe)"
+    "- gdf_cat (dataframe)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "%%time\n",
     "\n",
     "## read catchment geopackage\n",
     "gdf_cat = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    cat_gpkg = os.path.join(\n",
-    "        geospatial_dir, catch_gpkg[grid][\"file_name\"]\n",
+    "        geospatial_dir, catch_gpkg[meta[\"grid\"]][\"file_name\"]\n",
     "    )  # geopackage name\n",
-    "    id_name_cat = catch_gpkg[grid][\"id_name\"]  # reach ID in geopackage\n",
+    "    id_name_cat = catch_gpkg[meta[\"grid\"]][\"id_name\"]  # reach ID in geopackage\n",
     "    var_list = [id_name_cat]\n",
     "    if \"lk\" in grid_name:\n",
     "        var_list.append(\"lake\")\n",
@@ -416,23 +542,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "### 3.4 Read river outlet information\n",
+    "- Apppend into gdf_cat (dataframe)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
     "\n",
     "# read river outlet netcdf\n",
     "riv_ocean = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    riv_ocean_file = os.path.join(\n",
-    "        domain_dir, network_nc[grid][\"file_name\"].replace(\".aug.nc\", \".outlet.nc\")\n",
+    "        domain_dir,\n",
+    "        network_nc[meta[\"grid\"]][\"file_name\"].replace(\".aug.nc\", \".outlet.nc\"),\n",
     "    )  # network netcdf name\n",
     "    ds_rn_ocean = xr.open_dataset(riv_ocean_file).set_index(seg=\"seg_id\")\n",
     "    df_tmp = ds_rn_ocean.to_dataframe()\n",
     "    riv_ocean[case] = pd.merge(\n",
-    "        gdf_cat[case], df_tmp, left_on=catch_gpkg[grid][\"id_name\"], right_index=True\n",
+    "        gdf_cat[case],\n",
+    "        df_tmp,\n",
+    "        left_on=catch_gpkg[meta[\"grid\"]][\"id_name\"],\n",
+    "        right_index=True,\n",
     "    )"
    ]
   },
@@ -448,14 +600,22 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%time\n",
     "\n",
     "# Merge gauge_reach lnk (dataframe) into gauge shapefile\n",
     "gauge_shp1 = {}\n",
-    "for case, grid in zip(case_list, grid_list):\n",
+    "for case, meta in case_dic.items():\n",
     "    df = gauge_reach_lnk[case]\n",
     "\n",
     "    # df = df.loc[(df['flag'] == 0)]\n",
@@ -466,26 +626,36 @@
     "        riv_ocean[case],\n",
     "        how=\"inner\",\n",
     "        left_on=\"route_id\",\n",
-    "        right_on=catch_gpkg[grid][\"id_name\"],\n",
+    "        right_on=catch_gpkg[meta[\"grid\"]][\"id_name\"],\n",
     "    )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": []
    },
    "source": [
     "------\n",
-    "## 3. plot annual cycle for global oceans <a id='24_large_rivers'></a>\n",
-    "\n",
-    "TODO: Referece flow plot should be independent from cases (network). Currently the last case plotted looks better matched with reference flow. "
+    "## 3. Plot annual cycle for global oceans <a id='24_large_rivers'></a>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "hide-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "%time\n",
@@ -500,11 +670,11 @@
     "for ix, ocean_name in enumerate(oceans_list):\n",
     "    row = ix // 2\n",
     "    col = ix % 2\n",
-    "    for case, grid in zip(case_list, grid_list):\n",
+    "    for case, meta in case_dic.items():\n",
     "\n",
-    "        q_name = case_meta[grid][\"flow_name\"]\n",
+    "        q_name = case_meta[meta[\"grid\"]][\"flow_name\"]\n",
     "\n",
-    "        if case_meta[grid][\"network_type\"] == \"vector\":\n",
+    "        if case_meta[meta[\"grid\"]][\"network_type\"] == \"vector\":\n",
     "            if ocean_name == \"global\":\n",
     "                id_list = gauge_shp1[case][\"route_id\"].values\n",
     "            else:\n",
@@ -574,9 +744,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
-   "source": []
+   "source": [
+    "if client:\n",
+    "    client.shutdown()"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Based on discussion with Mike (@mnlevy1981), the following changes were made to resolve issue encountered in PR #197.
1) Remove `rof_start_date` and `rof_end_date` parameters from rof config
2) Add `climo_nyears` parameter in rof config
3) Adjust the rest of the codes based on changes 1) and 2)
4) Added hide-input cell tag
5) Allow dask distributed when running interactively.

Now both notebooks read the entire ROF history file and subset in time based on climo_nyears. I tested this with `cupid-diagnostics -rof` and `cupid-diagnostics -s -rof`

Let me know if I miss anything. 

### Description of changes:
* [x] Please add an explanation of what your changes do and why you'd like us to include them.

#### All PRs Checklist:
* [ ] Have you followed the guidelines in our [Contributor's Guide](https://ncar.github.io/CUPiD/contributors_guide.html)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [ ] Have you made sure that the [`pre-commit` checks passed (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html)?
* [ ] Have you successfully tested your changes locally?

#### New notebook PR Additional Checklist (if these do not apply, feel free to remove this section):
* [ ] Have you [hidden the code cells (#8 in Adding Notebooks Guide)](https://ncar.github.io/CUPiD/addingnotebookstocollection.html) in your notebook?
* [ ] Have you removed any unused parameters from your cell tagged with `parameters`? These can cause confusing warnings that show up as `DAG build with warnings`.
* [ ] Have you moved any observational data that you are using to `/glade/campaign/cesm/development/cross-wg/diagnostic_framework/CUPiD_obs_data` and ensured that it follows this format within that directory: `COMPONENT/analysis_datasets/RESOLUTION/PROCESSED_FIELD_TYPE`?
